### PR TITLE
cmd/bwreserver: specify reservation independent of sending rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![GitHub issues](https://img.shields.io/github/issues/anapaya/bwallocation/help%20wanted.svg?label=help%20wanted&color=purple)](https://github.com/anapaya/bwallocation/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
 [![GitHub issues](https://img.shields.io/github/issues/anapaya/bwallocation/good%20first%20issue.svg?label=good%20first%20issue&color=purple)](https://github.com/anapaya/bwallocation/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
 [![Release](https://img.shields.io/github/release-pre/anapaya/bwallocation.svg)](https://github.com/anapaya/bwallocation/releases)
-[![License](https://img.shields.io/github/license/anapaya/bwallocation.svg?maxAge=2592000)](https://github.com/anapaya/bwallocation/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/Anapaya/bwallocation.svg?maxAge=2592000)](https://github.com/Anapaya/bwallocation/blob/main/LICENSE)
 
 `bwallocation` is a go library for establishing bandwidth reservations in the
 bandwidth allocation system.
@@ -93,24 +93,31 @@ Usage:
   bwreserver client <server-addr> [flags]
 
 Examples:
-  bwreserver client 1-ff00:0:112,127.0.0.1:9000 -b 5mbps -d 10
-  bwreserver client 1-ff00:0:112,127.0.0.1:9000 --quic
+  bwreserver client 1-ff00:0:112,127.0.0.1:9000 -s 5mbps -d 10
+  bwreserver client 1-ff00:0:112,127.0.0.1:9000 -s 10mbps -r 5mbps
   bwreserver client 1-ff00:0:112,127.0.0.1:9000 --text
 
 
 Flags:
-  -b, --bandwidth string   bandwidth to reserve. If --best-effort is provided, the client will attempt to send at the specified rate. (default "1mbps")
-      --best-effort        send best effort traffic without any reservation
-  -d, --duration int       duration of the data transmission in seconds. 0 or negative values will keep the data transmission going indefinitely.
-  -h, --help               help for client
-  -i, --interactive        interactive mode
-      --local ip           IP address to listen on
-      --log.level string   Console logging level verbosity (debug|info|error)
-      --pprof tcp-addr     Address to serve pprof (default :0)
-      --quic               use QUIC when sending data. If not specified, UDP is used.
-      --sciond string      SCION Daemon address (default "127.0.0.1:30255")
-      --sequence string    Space separated list of hop predicates
-      --text               use simple text mode. If not specified, the CLI widgets output is used.
+  -d, --duration int          duration of the data transmission in seconds.
+                              0 or negative values will keep the data transmission going indefinitely.
+  -h, --help                  help for client
+  -i, --interactive           interactive mode
+      --local ip              IP address to listen on
+      --log.level string      Console logging level verbosity (debug|info|error)
+      --payload int           payload size in bytes (default 1280)
+      --pprof tcp-addr        Address to serve pprof (default :0)
+      --quic                  use QUIC when sending data. If not specified, UDP is used.
+  -r, --reservation string    bandwidth to reserve. Setting this lower than sending rate simulates malicious behavior.
+                              supported values:
+                                <bandwidth>:  Reserve the specified bandwidth
+                                sending-rate: Use same value as sending-rate
+                                none:         Do not reserve any bandwidth
+                               (default "sending-rate")
+      --sciond string         SCION Daemon address (default "127.0.0.1:30255")
+  -s, --sending-rate string   rate the client attempts to send at (default "1mbps")
+      --sequence string       Space separated list of hop predicates
+      --text                  use simple text mode. If not specified, the CLI widgets output is used.
 ```
 
 ## Screenshots

--- a/cmd/bwreserver/server/server.go
+++ b/cmd/bwreserver/server/server.go
@@ -34,6 +34,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	pb "github.com/anapaya/bwallocation/proto/bwreserver/v1"
+	"github.com/anapaya/bwallocation/reservation"
 	"github.com/scionproto/scion/go/lib/addr"
 	"github.com/scionproto/scion/go/lib/fatal"
 	"github.com/scionproto/scion/go/lib/infra/infraenv"
@@ -538,6 +539,7 @@ func headerLen(sender *snet.UDPAddr, localAddrLen int) int {
 		2*addr.IABytes +
 		senderAddrLen +
 		localAddrLen +
+		reservation.MetaLen + // Meta header is stripped in reversal.
 		len(sender.Path.Raw) +
 		8 // UDP/SCION header
 }


### PR DESCRIPTION
Decouple the reservation size from the desired sending rate.
The as part of change, the flag set changes:

- `-b`: is removed
- `-s`, `--sending-rate`: specify the desired sending rate
- `-r`, `--reservation`: specify the reservation size
- `--payload`: specify the payload size.

This change allows us to simulate a malicious hosts that do not respect
their reservation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/bwallocation/2)
<!-- Reviewable:end -->
