### PR TITLE
goreleaser: do not publish source

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,9 +14,6 @@ archives:
   - replacements:
       linux: linux
       amd64: 64-bit
-source:
-  enabled: true
-  name_template: "{{ .ProjectName }}_{{ .Version }}_source"
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Do not publish source through goreleaser. Github automatically adds
the full source anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/bwallocation/3)
<!-- Reviewable:end -->
