### PR TITLE
cmd/bwreserver: attach error details

### DIFF
--- a/cmd/bwreserver/client/client.go
+++ b/cmd/bwreserver/client/client.go
@@ -432,8 +432,9 @@ func (c *client) fetchStatsFromRemote(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			newCtx, cancel := context.WithTimeout(ctx, time.Second)
+			newCtx, cancel := context.WithTimeout(ctx, pollingInterval/2)
 			defer cancel()
+
 			response, err := client.Stats(newCtx, request)
 			if err != nil {
 				select {

--- a/manager.go
+++ b/manager.go
@@ -32,6 +32,7 @@ import (
 	"github.com/scionproto/scion/go/lib/spath"
 	"github.com/scionproto/scion/go/lib/util"
 	"github.com/scionproto/scion/go/pkg/grpc"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -233,6 +234,9 @@ func (s *Subscription) fetchToken(ctx context.Context) error {
 		Path:           s.info.Path.Raw,
 	})
 	if err != nil {
+		if st, ok := status.FromError(err); ok && len(st.Details()) > 0 {
+			return serrors.WithCtx(err, "details", st.Details())
+		}
 		return err
 	}
 


### PR DESCRIPTION
Attach error details when available.

- If the requested bandwidth cannot be allocated, the details contain
  a bandwidth hint with the maximum that is possible at the time of the
  request
- If the requested expiration time is too far in the future, the details
  contain the maximum expiration time at the time of the request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/bwallocation/6)
<!-- Reviewable:end -->
